### PR TITLE
Fix strict mode compatibility

### DIFF
--- a/angular-slug.js
+++ b/angular-slug.js
@@ -4,22 +4,31 @@
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
 
-angular.module('slug', [])
+(function() {
+  'use strict';
+
+  angular.module('slug', [])
+    .provider('slug', slugProvider)
+    .filter('slug', slugFilter);
+
+  slugProvider.$inject = [];
+  slugFilter.$inject = ['slug'];
 
   /**
    * Simple slug wrapper as provider.
    */
-  .provider('slug', function () {
-    slug.$get = function () {
+  function slugProvider() {
+    slug.$get = function() {
       return slug;
     }
-
     return slug;
-  })
+  }
 
   /**
    * Slugifies a given string.
    */
-  .filter('slug', function (slug) {
+  function slugFilter(slug) {
     return slug;
-  });
+  }
+
+})();

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-slug",
   "main": "angular-slug.js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "authors": [
     "Lucas Constantino Silva"
   ],

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "tests"
   ],
   "dependencies": {
-    "slug": "~0.8.0",
-    "angular": "~1.3.15"
+    "slug": "~0.9.1",
+    "angular": "~1.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Lucas Constantino Silva",
   "license": "MIT",
   "dependencies": {
-    "angular": "^1.3.15",
-    "slug": "^0.8.0"
+    "angular": "^1.5.7",
+    "slug": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-slug",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type" : "git",
     "url" : "http://github.com/lucasconstantino/angular-slug.git"


### PR DESCRIPTION
Hej, this awesome and tiny wrapper to slug was exactly what I was looking for.

But it doesn’t work with Angulars [strict-di mode](https://docs.angularjs.org/error/$injector/strictdi?p0=slugFilter).

This PR:
- Fixes compatibility with strict-di mode
- Updates dependencies 
  - Fixes #1 
- Bumps version in manifest files 
  - `bower.json` and `package.json`

So all you need to do is:
- merge 
- Tag release
- npm publish

:octocat: 
